### PR TITLE
Add 'Question' issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -11,7 +11,7 @@ assignees: ''
 _Write your question here_
 
 # Section
-_(optional) If this references existing content, provide a link/URL to the section _
+_(optional) If this references existing content, provide a link/URL to the section_
 
 # Notes
-_Helpful notes, concerns, or topics that would be helpful in providing the best answer possible_
+_(optional) Helpful notes, concerns, or topics that would be helpful in providing the best answer possible_

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,17 @@
+---
+name: Question
+about: Ask a question about something in or not in the handbook
+title: ''
+labels: question
+assignees: ''
+
+---
+
+# Question
+_Write your question here_
+
+# Section
+_(optional) If this references existing content, provide a link/URL to the section _
+
+# Notes
+_Helpful notes, concerns, or topics that would be helpful in providing the best answer possible_


### PR DESCRIPTION
Added a new type of Issue template for asking questions.

The three fields it asks for are:

- Question: What is your question
- Section (optional): Link to the relevant section if it references specific content
- Notes (optional): Other information or context that would be helpful for providing a great answer

I also added a `question` label in Issues as well.