### PR TITLE
Adds an ordered table of contents

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -71,6 +71,8 @@ module.exports = function (eleventyConfig) {
     return [...tagSet];
   });
 
+  // Combines metadata on pages that use the section layout with the ordering in the table of contents file
+  // Is used to generate nav items and get metadata on page ordering
   eleventyConfig.addCollection('sections', collection => {
     const tableOfContentsData = require('./_data/table_of_contents.json');
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -79,7 +79,7 @@ module.exports = function (eleventyConfig) {
       return {
         data: matchingPage.data,
         page: matchingPage.page,
-        order: index + 1 // Adding 1 to the index to start from 1 instead of 0
+        order: index
       };
     });
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -78,6 +78,20 @@ module.exports = function (eleventyConfig) {
     return [...tagSet];
   });
 
+  eleventyConfig.addCollection('combinedCollection', collection => {
+    const tableOfContentsData = require('./_data/table_of_contents.json');
+
+    const combinedData = tableOfContentsData.map((fileSlug, index) => {
+      const matchingPage = collection.getAll().find(item => item.page.fileSlug === fileSlug);
+      return {
+        page: matchingPage,
+        order: index + 1 // Adding 1 to the index to start from 1 instead of 0
+      };
+    });
+
+    return combinedData;
+  });
+
   // Copy the `img` and `css` folders to the output
   eleventyConfig.addPassthroughCopy('img');
   eleventyConfig.addPassthroughCopy('css');

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -71,7 +71,7 @@ module.exports = function (eleventyConfig) {
     return [...tagSet];
   });
 
-  eleventyConfig.addCollection('combinedCollection', collection => {
+  eleventyConfig.addCollection('sections', collection => {
     const tableOfContentsData = require('./_data/table_of_contents.json');
 
     const combinedData = tableOfContentsData.map((fileSlug, index) => {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -61,13 +61,6 @@ module.exports = function (eleventyConfig) {
     return (tags || []).filter(tag => ['all', 'nav'].indexOf(tag) === -1);
   })
 
-  // Create a collection for sections in alphabetical title order
-  eleventyConfig.addCollection('sections', function (collection) {
-    return collection.getFilteredByTag('section').sort((a, b) => {
-      return a.data.title.localeCompare(b.data.title);
-    });
-  });
-
   // Create an array of all tags
   eleventyConfig.addCollection('tagList', function (collection) {
     const tagSet = new Set();
@@ -84,7 +77,8 @@ module.exports = function (eleventyConfig) {
     const combinedData = tableOfContentsData.map((fileSlug, index) => {
       const matchingPage = collection.getAll().find(item => item.page.fileSlug === fileSlug);
       return {
-        page: matchingPage,
+        data: matchingPage.data,
+        page: matchingPage.page,
         order: index + 1 // Adding 1 to the index to start from 1 instead of 0
       };
     });

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ The Bloom Works employee handbook, with our policies and norms.
 
 This requires Docker to be installed and running
 
-1. Build the container: `docker build -t bloom-works/guides-template .`
-1. Start the server: `docker run -it --rm -p "8080:8080" bloom-works/guides-template`
+1. Build the container: `docker build -t bloom-works/handbook .`
+1. Start the server: `docker run -it --rm -p "8080:8080" bloom-works/handbook`
 1. View the site in your browser at [http://localhost:8080](http://localhost:8080)
 
 ## Developer Setup
@@ -16,8 +16,8 @@ This requires Docker to be installed and running
 This sets up the site with a consistent runtime environment, and requires Docker to be installed and running.
 
 1. Navigate to the base of this repo
-1. Build the container: `docker build -t bloom-works/guides-template .`
-1. Start a terminal inside the container: `docker run -it --rm -p "8080:8080" -v "$PWD:/app" bloom-works/guides-template bash`
+1. Build the container: `docker build -t bloom-works/handbook .`
+1. Start a terminal inside the container: `docker run -it --rm -p "8080:8080" -v "$PWD:/app" bloom-works/handbook bash`
 1. Install dependencies (first time only or when `package.json` changes): `npm install`
 1. Start server: `npm run serve`
 1. View the site in your browser at [http://localhost:8080](http://localhost:8080)
@@ -46,6 +46,7 @@ To add a new section to the site:
     - `layout: layouts/section`
     - `title: My New Section's Title`
 1. Add content below the second `---`
+1. Add the base of the file name into the `_data/table_of_contents.json` file in the desired order. For example, if you section is called `super-important.md`, then you would add the `"super-important"` (no `.md`) into the `_data/table_of_contents.json`.
 
 Feel free to look at any of the existing sections as a starting point.
 

--- a/_data/table_of_contents.json
+++ b/_data/table_of_contents.json
@@ -1,0 +1,4 @@
+[
+    "test-section",
+    "another-test-section"
+]

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -1,3 +1,23 @@
+{#--- Collect metadata about the current page (items are null if not a section) ---#}
+{% set thisSection = null %}
+{% set priorSection = null %}
+{% set nextSection = null %}
+
+{% for section in collections.sections %}
+  {% if section.page.fileSlug === page.fileSlug %}
+    {% set thisSection = section %}
+
+    {% if thisSection.order != 0 %}
+      {% set priorSection = collections.sections[thisSection.order-1] %} 
+    {% endif %}
+
+    {% if collections.sections|length >= thisSection.order %}
+      {% set nextSection = collections.sections[thisSection.order+1] %}
+    {% endif %}
+  {% endif %}
+{% endfor %}
+
+{#--- Layouts to include ---#}
 {% include "layouts/head.njk" %}
 {% include "layouts/seo.njk" %}
 {% include "layouts/css.njk" %}
@@ -5,6 +25,7 @@
 {% include "layouts/content.njk" %}
 {% include "layouts/footer.njk" %}
 
+{#--- Events for Nav ---#}
 <script>
   const allSectionsButton = document.querySelector("#all-sections-button");
   const allSectionsModal = document.querySelector("#all-sections-modal");

--- a/_includes/layouts/navigation.njk
+++ b/_includes/layouts/navigation.njk
@@ -34,7 +34,7 @@
   </header>
   <section class="dialog-body">
     <ol>
-      {% for section in collections.sections %}
+      {% for section in collections.combinedCollection %}
         <li>
           <a href="{{ section.page.url }}">{{ section.data.title }}</a>
         </li>

--- a/_includes/layouts/navigation.njk
+++ b/_includes/layouts/navigation.njk
@@ -34,7 +34,7 @@
   </header>
   <section class="dialog-body">
     <ol>
-      {% for section in collections.combinedCollection %}
+      {% for section in collections.sections %}
         <li>
           <a href="{{ section.page.url }}">{{ section.data.title }}</a>
         </li>

--- a/index.njk
+++ b/index.njk
@@ -33,28 +33,3 @@ title: Home
     <li>Item Two</li>
     <li>Item Three</li>
   </ol>
-
-
-<h1>collections</h1>
-<ol>
-  {% for section in collections.sections %}
-    <li>
-      Page: {{ section.page | dump }} <br/> 
-      Title: {{section.data.title}} <br/> 
-      URL: {{section.page.url}}
-    </li>
-  {% endfor %}
-</ol>
-
-
-<h1>TOC</h1>
-{{ table_of_contents | dump }}
-
-<h1>Combined Data</h1>
-<ol>
-  {% for section in collections.combinedCollection %}
-    <li>
-      {{ section.page.fileSlug }} -- {{section.page.url}} -- {{ section.page.data.title }}
-    </li>
-  {% endfor %}
-</ol>

--- a/index.njk
+++ b/index.njk
@@ -33,3 +33,28 @@ title: Home
     <li>Item Two</li>
     <li>Item Three</li>
   </ol>
+
+
+<h1>collections</h1>
+<ol>
+  {% for section in collections.sections %}
+    <li>
+      Page: {{ section.page | dump }} <br/> 
+      Title: {{section.data.title}} <br/> 
+      URL: {{section.page.url}}
+    </li>
+  {% endfor %}
+</ol>
+
+
+<h1>TOC</h1>
+{{ table_of_contents | dump }}
+
+<h1>Combined Data</h1>
+<ol>
+  {% for section in collections.combinedCollection %}
+    <li>
+      {{ section.page.fileSlug }} -- {{section.page.url}} -- {{ section.page.data.title }}
+    </li>
+  {% endfor %}
+</ol>


### PR DESCRIPTION
## Pull Request Background

Adds a table of contents that allows for manual ordering of pages, but still while pulling metadata from pages.

### GitHub Issue

Addresses #90 , where the team decided on an ordered rather than alphabetical section listing for the Handbook.

### What Changed

- Changes the `sections` collection to use `_data/table_of_contents.json`, instead of an alphabetical listing of section pages.
- Documentation on how to add something to the table of contents
- Some functionality in the base layout that collects information on the current section page. In a future PR, this will enable things like "Previous" and "Next links

### How to verify

- [ ] Sections show up in the same order as indicated in the `_data/table_of_contents.json`
- [ ] `README.md` instructions are clear

### Additional info

Not in this pull request, but in future ones we might want to consider the following features:

- "Previous" and "Next" links on section pages
- The table of contents may benefit from a chapter-based hierarchy. For example, sections might live within a certain chapter or topic.

