### PR TITLE
Added more verbose contributing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+This is a 🌲 living handbook 🌲 that we will evolve and adapt as we grow. Follow the instructions below if you see anything that is out of date, incorrect, or you have a concern – or if you would like to contribute to updates.
+
+- **Suggest an update**: Submit an issue to the GitHub repo using the ‘Comment or suggestion’ issue template. If you don’t have a GitHub account yet, drop your comment in #bloom-handbook, and be sure to include context that will help us prioritize and take action:
+    - What do you want to be able to do or understand? 
+    - If there's something missing or confusing about the handbook, how is this impacting you (or might impact you in the future)? 
+    - Use a user story format to put this suggestion in context, ex: As a [USER OR ROLE], I want [SOMETHING, OR TO DO SOMETHING], because/so that [WHY]
+    - Other notes, context, concerns, or topics that would be helpful for the handbook team to take action on this_
+- **Contribute updates**: Open a pull request.
+
+# How we’ll monitor and implement contributions
+
+We will monitor Slack and GitHub weekly for new questions, suggestions, and contributions.  We will capture most contributions as GitHub issues to keep the backlog open and in one place — with some exceptions:
+
+- **Questions**: Some questions will be straightforward, and we will answer these in other channels (e.g., Slack, conversation). Some questions may be more involved and require more work, in which case we will create GitHub issues for them. 
+- **Suggestions** and contributions*: We will create GitHub issues to track these. If we make an update to the handbook based on a suggestion, we will do this via pull request linked to the issue. 
+- **Contributions**: We will capture and track these as pull requests linked to issues that provide context. 
+
+We will refine GitHub issues by adding or clarifying a few things (and may follow up with the submitter on these):
+
+- User stories for context
+- A definition of done (this will always include approval by the section owner)
+- Any other context from the submitter
+
+# Prioritizing contributions 
+
+Once refined, we will prioritize and respond to issues within 10 business days. We will consider these factors in prioritizing:
+
+- What is required for legal/regulatory compliance
+- Relevance for onboarding new staff
+- Relevance for ongoing projects
+- How urgent or timely the need is
+
+# Drafting or updating content
+
+Once prioritized, we will assign one person to address the issue. 
+
+- **For questions and suggestions**: We will review current handbook content, decide what updates are appropriate, and draft those updates via pull request. 
+- **For contributions**: We will review the pull request.  
+
+We will default to discussing the issue using comments on the Github issue. This will help keep conversation open and in one place. 
+
+# Reviewing and merging contributions 
+
+Every section will have 2 or more reviewers, documented in `CODEOWNERS.md` and in the corresponding section of the handbook. 
+
+General review responsibilities:
+
+- Anything with financial implication - Lauren, or Emdash, or Sofia
+- Policies and code of conduct - Lauren, or Emdash, or Dottie
+- People, process, company rituals - Dottie or Emdash
+- Everything else - by directors or company leadership
+
+Again, we will default to discussing the issue in Github to keep conversation open and in one place.

--- a/index.md
+++ b/index.md
@@ -23,10 +23,10 @@ We invite contributions, whether you have a question ( “How do I do ABC?”), 
 
 * **Ask a question**: Hop into #bloom-handbook, or talk with your manager about questions that are more individual or sensitive.
 * **Suggest an update**: Submit an issue to the GitHub repo using the [‘Comment or suggestion’ issue template](https://github.com/bloom-works/handbook/issues/new?assignees=&labels=&projects=&template=comment-or-suggestion.md&title=). If you don’t have a GitHub account yet, drop your comment in #bloom-handbook, and be sure to include context that will help us prioritize and take action:
-* What do you want to be able to do or understand?
-* If there's something missing or confusing about the handbook, how is this impacting you (or might impact you in the future)?
-* Use a user story format to put this suggestion in context, ex: As a [USER OR ROLE], I want [SOMETHING, OR TO DO SOMETHING], because/so that [WHY].
-* Other notes, context, concerns, or topics that would be helpful for the handbook team to take action on this.
+    * What do you want to be able to do or understand?
+    * If there's something missing or confusing about the handbook, how is this impacting you (or might impact you in the future)?
+    * Use a user story format to put this suggestion in context, ex: As a [USER OR ROLE], I want [SOMETHING, OR TO DO SOMETHING], because/so that [WHY].
+    * Other notes, context, concerns, or topics that would be helpful for the handbook team to take action on this.
 * **Contribute updates**: [Open a pull request](https://github.com/bloom-works/handbook/pulls).
 
 For more about how we process and potentially implement changes, see CONTRIBUTING.md.


### PR DESCRIPTION
## Pull Request Background

Adding contributing instructions to complement the brief version on the main about/index page. We can update this with instructions later on how reviews are auto-assigned.

### GitHub Issue

#34 

### What Changed

- Added `CONTRIBUTING.md`
- Cleaned up formatting on contributing on the main about/index page

