### PR TITLE
Clarify working hours expectations

### DIFF
--- a/sections/time-off.md
+++ b/sections/time-off.md
@@ -36,8 +36,8 @@ Here is what you need ot do if you have been summoned:
 * When you get a summons to appear in court, let your engagement manager, director, and People Ops know that you may be potentially called to duty
 * If you are called to serve, let those same folks know and keep us updated on the status.
 * Once your service has been completed, send [People Ops](mailto:blossom@bloomworks.digital) your proof of service and log the time under "Jury Duty" in Gusto.
-    * If your duty is over 40 hours, you may use unpaid time off or PTO.
-    * 
+* If your duty is over 40 hours, you may use unpaid time off or PTO.
+
 If you’re appearing in your own case as a plaintiff or defendant or for a non-subpoenaed court appearance, you’ll need to use personal time, floating holidays, or unpaid time rather than Jury leave.
 
 *Canadian process coming soon
@@ -78,7 +78,7 @@ Please take a look at [our emergency leave doc](https://docs.google.com/document
 
 Time off is important, and we want Bloomers to take the time they need. We ask you to request leave in advance and communicate about your leave thoroughly because we need to be able to predict project timelines and manage teams’ workloads responsibly. We try to approve most requests, but don’t make nonrefundable plans before your leave is cleared!
 
-If you need to accommodate an appointment or event during business hours, you may be able to shift your working hours that day instead of taking leave. If you do that, make sure your availability is reflected on your calendar and your manager is aware.
+If you need to accommodate an occasional appointment or event during business hours, you may be able to shift your working hours that day instead of taking leave. If you do that, make sure your availability is reflected on your calendar and your manager is aware. If you want to regularly work an alternate schedule to accommodate recurring committments, work with your team and manager to approve your schedule and make sure it's accurately reflected (see [Working hours](https://handbook.bloomworks.digital/sections/working-hours/)).
 
 
 ### Before taking **planned leave**, be sure to

--- a/sections/time-off.md
+++ b/sections/time-off.md
@@ -78,7 +78,7 @@ Please take a look at [our emergency leave doc](https://docs.google.com/document
 
 Time off is important, and we want Bloomers to take the time they need. We ask you to request leave in advance and communicate about your leave thoroughly because we need to be able to predict project timelines and manage teams’ workloads responsibly. We try to approve most requests, but don’t make nonrefundable plans before your leave is cleared!
 
-If you need to accommodate an occasional appointment or event during business hours, you may be able to shift your working hours that day instead of taking leave. If you do that, make sure your availability is reflected on your calendar and your manager is aware. If you want to regularly work an alternate schedule to accommodate recurring committments, work with your team and manager to approve your schedule and make sure it's accurately reflected (see [Working hours](https://handbook.bloomworks.digital/sections/working-hours/)).
+If you need to accommodate an occasional appointment or event during business hours, you may be able to shift your working hours that day instead of taking leave. If you do that, make sure your availability is reflected on your calendar and your manager is aware. Please make sure your availability is legible to colleagues by setting and communicating your [Working hours](https://handbook.bloomworks.digital/sections/working-hours/).
 
 
 ### Before taking **planned leave**, be sure to

--- a/sections/working-hours.md
+++ b/sections/working-hours.md
@@ -10,8 +10,7 @@ We love being a remote-first company and getting to work with people from across
 
 As a default, we expect Bloomers to work during normal business hours in their time zone. This allows us to have 4.5 hours of overlap from 12-4:30pm ET (9-1:30pm PT), during which we try to schedule most meetings and can count on each other to be working. 
 
-If you want to work a schedule that does not include 12-4:30pm ET from Monday through Friday, you need approval from your manager.
-
+If you need to work a schedule that does not include 12-4:30pm ET from Monday through Friday, you need approval from your manager.
 
 ## Respecting working hours
 
@@ -31,4 +30,3 @@ If you’re traveling and will be in a different timezone than usual, enable the
 You can also set a notification schedule in Slack, which lets coworkers know if they’re messaging you outside your working hours.
 
 If you’ll be out of the office, see [communicating time off](/sections/time-off/#communicating-time-off).
-


### PR DESCRIPTION
We recently realized we need to clarify some of our expectations around shifting working hours for personal appointments or events. (The handbook previously noted that it is allowed, but didn't provide any guardrails around how much is too much.)

### What Changed

- Clarified that flexing time for appointments/event should be "occasional"
- Added an additional sentence about making working hours legible, with cross-link to "Working hours" page

