### PR TITLE
Remove 'Team' from footer

### DIFF
--- a/_includes/layouts/footer.njk
+++ b/_includes/layouts/footer.njk
@@ -15,8 +15,7 @@
         <div>
           <h3 class="h4">About Us</h3>
           <ul>
-            <li><a href="https://bloomworks.digital/mission/">Our Mission</a></li>
-            <li><a href="https://bloomworks.digital/team/">Our Team</a></li>
+            <li><a href="https://bloomworks.digital/mission/">Mission</a></li>
             <li><a href="https://bloomworks.digital/jobs/">Jobs</a></li>
           </ul>
         </div>


### PR DESCRIPTION
This link no longer exists on our website, so removing from the footer nav.
